### PR TITLE
spacing fix

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -36,7 +36,7 @@ async def createServerResponseHandler(s):
             if len(data) == 0:
                 print("Error: Disconnected from server!")
                 return stop()
-            print(f"{data.decode('utf-8')}")
+            print(f"{data.decode('utf-8')}", end="")
         except asyncio.TimeoutError:
             pass
 

--- a/UnoCPP/view/text_view.cpp
+++ b/UnoCPP/view/text_view.cpp
@@ -70,8 +70,9 @@ void StreamView::output_message(const std::string& msg)
 
 void SocketView::output_message(const std::string& msg)
 {
+	std::string to_output = msg + "\n";
 	for (auto& socket : _sockets) {
-		_server.send_client_message(socket, msg);
+		_server.send_client_message(socket, to_output);
 	}
 }
 


### PR DESCRIPTION
Fixes an issue with client read buffer containing two messages from server, which causes a spacing issue in terms of a new line missing